### PR TITLE
ユーザー登録時のvalidation/エラーメッセージの表示、SNS認証を扱うための下準備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'pry-rails'
+  gem 'omniauth'
+  gem 'omniauth-google-oauth2'
+  gem 'omniauth-facebook'
 end
 
 group :development do
@@ -73,4 +76,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem 'fog-aws'
   gem "payjp"
   gem "gretel"
-
+  gem 'dotenv-rails'
+  gem "recaptcha", require: "recaptcha/rails"
+  gem "moji"
+  gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubis (2.7.0)
     excon (0.64.0)
     execjs (2.7.0)
@@ -91,6 +95,8 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     fog-aws (3.5.1)
       fog-core (~> 2.1)
@@ -124,6 +130,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashie (3.6.0)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -140,6 +147,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.2.0)
+    jwt (2.2.1)
     kgio (2.11.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -157,7 +166,10 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    moji (1.6)
     multi_json (1.13.1)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     mysql2 (0.5.2)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
@@ -166,6 +178,24 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-facebook (5.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-google-oauth2 (0.7.0)
+      jwt (>= 2.0)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.5)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
     orm_adapter (0.5.0)
     payjp (0.0.7)
       rest-client (~> 2.0)
@@ -195,6 +225,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.0.7.2)
       actionpack (= 5.0.7.2)
       activesupport (= 5.0.7.2)
@@ -206,6 +239,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    recaptcha (5.0.0)
+      json
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -299,6 +334,7 @@ DEPENDENCIES
   carrierwave
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   factory_bot_rails
   fog-aws
   font-awesome-rails
@@ -308,12 +344,17 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mini_magick
+  moji
   mysql2 (>= 0.3.18, < 0.6.0)
+  omniauth
+  omniauth-facebook
+  omniauth-google-oauth2
   payjp
-
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
+  rails-i18n
+  recaptcha
   rspec-rails
   sass-rails (~> 5.0)
   spring

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -58,7 +58,8 @@ var {
 }
 
 ol,
-ul {
+ul,
+li{
   list-style:none;
 }
 

--- a/app/assets/stylesheets/signup/_member_info.scss
+++ b/app/assets/stylesheets/signup/_member_info.scss
@@ -38,6 +38,12 @@
           padding: 0 20px;
           box-sizing: border-box;
         }
+        .error-message{
+          color: #ea352d;
+          line-height: 1.5;
+          font-size: 14px;
+          margin: 8px 0 0;
+        }
 /*        &__box::placeholder {
           padding-left: 20px;
         }*/
@@ -47,10 +53,10 @@
           border-radius: 4px;
           border: 1px solid #cccccc;
           margin-top: 5px;
-          margin-bottom: 32px;
           margin-right: 5px;
           padding: 0 20px;
           box-sizing: border-box;
+          float: left;
         }
         &__box-name-bottom {
           width: 155px;
@@ -58,7 +64,6 @@
           border-radius: 4px;
           border: 1px solid #cccccc;
           margin-top: 5px;
-          margin-bottom: 32px;
           padding: 0 20px;
           box-sizing: border-box;
         }
@@ -68,7 +73,6 @@
           border-radius: 4px;
           border: 1px solid #cccccc;
           margin-top: 5px;
-          margin-bottom: 32px;
         }
       }
       &__identification {
@@ -114,56 +118,6 @@
         &__text {
           font-size: 14px;
           color: #0099e8;
-        }
-      }
-    }
-    &__confirm {
-      width: 304px;
-      height: 76px;
-      background-color: #f9f9f9;
-      position: relative;
-      z-index: 5;
-      &__checkbox {
-        width: 52px;
-        height: 76px;
-        float: left;
-        line-height: 76px;
-        text-align: center;
-        &__box {
-          transform: scale(2.0, 2.0);
-        }
-      }
-      &__text {
-        width: 152px;
-        height: 76px;
-        float: left;
-        padding-top: 20px;
-        font-size: 14px;
-        box-sizing: border-box;
-      }
-      &__icon {
-        width: calc(100% - 52px - 152px);
-        height: 76px;
-        float: left;
-        position: relative;
-        &__detail {
-          position: absolute;
-          top: 10px;
-          right: 20px;
-          color: blue;
-        }
-        &__text {
-          font-size: 10px;
-          position: absolute;
-          top: 45px;
-          right: 10px;
-        }
-        &__text-2 {
-          font-size: 10px;
-          position: absolute;
-          top: 60px;
-          right: 10px;
-          z-index: 100;
         }
       }
     }

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -8,7 +8,11 @@ class AddressesController < ApplicationController
 
   def create
     @address = Address.new(address_params)
-    render "user_info" unless @address.save
+    if @address.save
+      redirect_to complete_signup_index_path
+    else
+      render "user_info"
+    end
   end
 
   private

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -1,16 +1,16 @@
 class CreditsController < ApplicationController
 
   require "payjp"
-  
+
   def index
 
   end
-  
+
   def new
 
   end
 
-  def create    
+  def create
     Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
     customer = Payjp::Customer.create(card: params[:payjp_Token])
     @credit = Credit.create(user_id: current_user.id, customer_id: customer.id, card_token: params[:payjp_Token])

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,5 +1,7 @@
 class SignupController < ApplicationController
-  before_action :user_signed_in
+  require "moji"
+  before_action :user_signed_in, only: [:save_session1, :sms, :sms, :sms_authentication]
+
   def top
   end
 
@@ -8,21 +10,28 @@ class SignupController < ApplicationController
   end
 
   def save_session1
+    #MEMO tr_s!メソッドを使って入力された英数字を半角から全角に変換しています
+    user_params[:name_last].tr_s!("0-9a-zA-Z  ()-", "０-９ａ-ｚＡ-Ｚ 　（）－−")
+    user_params[:name_first].tr_s!("0-9a-zA-Z  ()-", "０-９ａ-ｚＡ-Ｚ 　（）－−")
+    user_params[:name_kana_first].tr_s!("0-9a-zA-Z  ()-", "０-９ａ-ｚＡ-Ｚ 　（）－−")
+    user_params[:name_kana_last].tr_s!("0-9a-zA-Z  ()-", "０-９ａ-ｚＡ-Ｚ 　（）－−")
+    #MEMO Mojiというgemを使ってユーザーの入力した名前を半角から全角に、カナ文字はひらがなからカタカナに変換しています(日本語に限る)
+    user_params[:name_last].replace(Moji.han_to_zen(user_params[:name_last]))
+    user_params[:name_first].replace(Moji.han_to_zen(user_params[:name_first]))
+    user_params[:name_kana_first].replace(Moji.han_to_zen(user_params[:name_kana_first]))
+    user_params[:name_kana_first].replace(Moji.hira_to_kata(user_params[:name_kana_first]))
+    user_params[:name_kana_last].replace(Moji.han_to_zen(user_params[:name_kana_last]))
+    user_params[:name_kana_last].replace(Moji.hira_to_kata(user_params[:name_kana_last]))
+
     @user = User.new(user_params)
-    session[:name] = user_params[:name]
-    session[:name_kana] = user_params[:name_kana]
-    session[:email] = user_params[:email]
-    session[:password] = user_params[:password]
-    session[:password_confirmation] = user_params[:password_confirmation]
-    session[:nickname] = user_params[:nickname]
-    session[:birthday] = @user.birthday
-    
-    if @user.valid?
+    #FIXME: @user.valid?がfalseだった場合に右の条件が読まれず、recaptcha用のエラー文が表示されない
+    if @user.valid? && verify_recaptcha(model: @user)
+      session[:user_session] = user_params
       redirect_to sms_signup_index_path
     else
+      #FIXME render時に入力した情報がURLに表示されてしまう
       render 'member_info'
     end
-
   end
 
   def sms
@@ -49,25 +58,21 @@ class SignupController < ApplicationController
 
   def create
     @user = User.new(
-    name: session[:name],
-    name_kana: session[:name_kana],
-    email: session[:email],
-    password: session[:password],
-    password_confirmation: session[:password_confirmation],
-    nickname: session[:nickname],
-    birthday: session[:birthday]
+      user_params = session[:user_session]
   )
 
     if @user.save
       session[:id] = @user.id
-      redirect_to complete_signup_index_path
+      sign_in User.find(session[:id]) unless user_signed_in?
+      redirect_to user_info_signup_index_path
     else
+      render top_signup_index_path
     end
   end
 
 private
   def user_params
-    params.require(:user).permit(:name, :name_kana, :email, :password, :password_confirmation, :nickname, :birthday)
+    params.require(:user).permit(:name_last, :name_first, :name_kana_last, :name_kana_first, :email, :password, :password_confirmation, :nickname, :birthday)
   end
 
   def user_signed_in

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,25 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+
+  def facebook
+    callback_for(:facebook)
+  end
+
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  def callback_for(provider)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
+    else
+      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+      redirect_to member_info_signup_index_path
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,12 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+
+
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: [:google_oauth2, :facebook]
 
   has_many :products
   has_many :comments
@@ -11,8 +15,21 @@ class User < ApplicationRecord
   has_one :credit
   has_one :address
 
-  validates :name, presence: true
-  validates :name_kana, presence: true
-  validates :nickname, presence: true
+  validates :name_last, presence: true
+  validates :name_first, presence: true
+  validates :name_kana_last, presence: true, format: { with: /\p{Katakana}/}
+  validates :name_kana_first, presence: true, format: { with: /\p{Katakana}/}
+  validates :email, presence: true, unless: :uid?
+  validates :password, presence: true, format: { with: /\A[a-zA-Z\d]+\z/}, unless: :uid?
+  validates :password_confirmation, presence: true, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]/i}, unless: :uid?
+  validates :nickname, presence: true, unless: :uid?
   validates :birthday, presence: true
+
+  protected
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0,20]
+    end
+  end
 end

--- a/app/views/signup/credit.html.haml
+++ b/app/views/signup/credit.html.haml
@@ -4,7 +4,7 @@
   .credit-contents
     %h2.credit-contents__head
       クレジットカード情報入力
-    = form_for(@user, url: credit_signup_index_path, method: :post, html:{class: "credit-contents__form"}) do |f|
+    = form_for(@credit, url: credit_signup_index_path, method: :post, html:{class: "credit-contents__form"}) do |f|
       .credit-contents__form-inner
         .credit-contents__form-inner--group
           %label

--- a/app/views/signup/member_info.html.haml
+++ b/app/views/signup/member_info.html.haml
@@ -9,68 +9,88 @@
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
         = f.text_field :nickname, placeholder: "例)メルカリ太郎", class: "member-info__body__main__input__box"
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:nickname).each do |message|
+            %li.error-message= message
 
       %span.member-info__body__main__text メールアドレス
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
         = f.email_field :email, placeholder: "PC・携帯どちらでも可", class: "member-info__body__main__input__box"
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:email).each do |message|
+            %li.error-message= message
+
       %span.member-info__body__main__text パスワード
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
         = f.password_field :password, placeholder: "6文字以上", autocomplete: "new-password", class: "member-info__body__main__input__box"
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:password).each do |message|
+            %li.error-message= message
 
       %span.member-info__body__main__text パスワード(確認)
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
         = f.password_field :password_confirmation, placeholder: "6文字以上", class: "member-info__body__main__input__box"
-      // MEMO 現状ユーザー登録で使うデータはname/email/passwordだけなのでコメントアウトしています！
-      -# .member-info__body__main__identification
-      -#   .member-info__body__main__identification__title
-      -#     本人確認
-      -#   .member-info__body__main__identification__contents
-      -#     安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:password_confirmation).each do |message|
+            %li.error-message= message
+ 
+      .member-info__body__main__identification
+        .member-info__body__main__identification__title
+          本人確認
+        .member-info__body__main__identification__contents
+          安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
 
       %span.member-info__body__main__text お名前(全角)
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
-        = f.text_field :name, placeholder: "例)山田 綾", class: "member-info__body__main__input__box-name"
-      -#   = f.text_field :name, placeholder: "例)彩", class: "member-info__body__main__input__box-name-bottom"
+        = f.text_field :name_last, placeholder: "例)山田 綾", class: "member-info__body__main__input__box-name"
+        = f.text_field :name_first, placeholder: "例)彩", class: "member-info__body__main__input__box-name-bottom"
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:name_first).each do |message|
+            %li.error-message= message
+
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:name_last).each do |message|
+            %li.error-message= message
+ 
 
       %span.member-info__body__main__text お名前カナ(全角)
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
-        = f.text_field :name_kana, placeholder: "例)ヤマダ アヤ", class: "member-info__body__main__input__box-name"
-      // MEMO ユーザー登録時に名字と名前を分けて登録する方法が現状わからないので、とりあえず一つのフォームでデータを送信するためコメントアウトしてあります！
-      -#   = f.text_field :name, placeholder: "例)アヤ", class: "member-info__body__main__input__box-name-bottom"
+        = f.text_field :name_kana_last, placeholder: "例)ヤマダ アヤ", class: "member-info__body__main__input__box-name"
 
-      //TODO 生年月日をバラバラに取得し、あとで結合させる
+        = f.text_field :name_kana_first, placeholder: "例)アヤ", class: "member-info__body__main__input__box-name-bottom"
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:name_kana_first).each do |message|
+            %li.error-message= message
+
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:name_kana_last).each do |message|
+            %li.error-message= message
+
       %span.member-info__body__main__text 生年月日
       %span.member-info__body__main__mark 必須
       .member-info__body__main__input
-        = f.date_select :birthday, {start_year: 1900, end_year: Time.current.year, use_month_numbers: true, date_separator: '/'}, {class: "member-info__body__main__input__box-date"}
-      -# .member-info__body__main__note
-      -#   .member-info__body__main__note__text
-      -#     ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+        = f.date_select :birthday, {start_year: 1900, end_year: (Time.current.year), include_blank: true, use_month_numbers: true, date_separator: '/' }, {class: "member-info__body__main__input__box-date"}
+        - if @user.errors.any?
+          - @user.errors.full_messages_for(:birthday).each do |message|
+            %li.error-message= message
 
-      -# .member-info__body__confirm
-      -#   .member-info__body__confirm__icon__text-2
-      -#     =link_to "#" do
-      -#       %span.member-info__body__confirm__icon__text-2__privacy
-      -#         プライバシー
-      -#     %span.member-info__body__confirm__icon__text-2__privacy
-      -#       ・
-      -#     =link_to "#" do
-      -#       %span.member-info__body__confirm__icon__text-2__terms
-      -#         利用規約
-      -#   .member-info__body__confirm__checkbox
-      -#     = f.text_field :robotconfirm, type: "checkbox", value: "1", class: "member-info__body__confirm__checkbox__box"
-      -#   .member-info__body__confirm__text
-      -#     私はロボットではありません
-      -#   .member-info__body__confirm__icon
-      -#     %i.fab.fa-accessible-icon.fa-2x.member-info__body__confirm__icon__detail
-      -#     .member-info__body__confirm__icon__text
-      -#       reCAPTCHA
+      .member-info__body__main__note
+        .member-info__body__main__note__text
+          ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
 
+      //MEMO この一行でreCAPTCHAの表示ができます
+      = recaptcha_tags
+
+      - if @user.errors.any?
+        - @user.errors.full_messages_for(:base).each do |message|
+          %li.error-message= message
+
+ 
       .member-info__body__main__agree
         .member-info__body__main__agree__text
           「次へ進む」のボタンを押すことにより、

--- a/app/views/signup/top.html.haml
+++ b/app/views/signup/top.html.haml
@@ -10,12 +10,12 @@
             %i.fas.fa-envelope.fa-lg.new-registration__body__bottom__mail-btn__icon
             メールアドレスで登録する
       .new-registration__body__bottom__facebook-btn
-        =link_to "#" do
+        =link_to user_facebook_omniauth_authorize_path do
           .new-registration__body__bottom__facebook-btn__scope
             %i.fab.fa-facebook-square.fa-2x.new-registration__body__bottom__facebook-btn__icon
             Facebookで登録する
       .new-registration__body__bottom__google-btn
-        =link_to "#" do
+        =link_to user_google_oauth2_omniauth_authorize_path do
           .new-registration__body__bottom__google-btn__scope
             %i.fab.fa-google.fa-lg.new-registration__body__bottom__google-btn__icon
             Googleで登録する

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,7 +12,7 @@
           .mypage-contents__main__user__avatar
             %img{alt: "", height: "60", src: "//static.mercdn.net/images/member_photo_noimage_thumb.png", width: "60"}/
           %h2.mypage-contents__main__user__name
-            = @user.name
+            = @user.nickname
           %span.mypage-contents__main__user__evaluation
             評価
             %span.mypage-contents__main__user__evaluation-count

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,12 +2,21 @@ require_relative 'boot'
 
 require 'rails/all'
 
+require 'dotenv'
+Dotenv.load
+Bundler.require(*Rails.groups)
+Dotenv::Railtie.load
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module FreemarketSample55A
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja 
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -296,4 +296,8 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+  require 'dotenv'
+
+  config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  config.omniauth :facebook, ENV['FACEBOOK_ID'], ENV['FACEBOOK_SECRET_KEY']
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,4 @@
+Recaptcha.configure do |config|
+  config.site_key = ENV['RECAPTCHA_SITE_KEY']
+  config.secret_key = ENV['RECAPTCHA_SECRET_KEY']
+end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,115 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は既に使用されています。"
+              blank: "を入力してください。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "を入力してください。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は英字と数字両方を含むように設定してください。"
+              confirmation: "が内容とあっていません。"
+            password_confirmation:
+              blank: "を入力してください。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              invalid: "は英字と数字両方を含むように設定してください。"
+            name_last:
+              blank: "を入力してください。"
+              invalid: "に数字や特殊文字は使用できません"
+            name_first:
+              blank: "を入力してください。"
+              invalid: "に数字や特殊文字は使用できません"
+            name_kana_last:
+              blank: "を入力してください。"
+              invalid: "に英数字や特殊文字は使用できません。"
+            name_kana_first:
+              blank: "を入力してください。"
+              invalid: "に英数字や特殊文字は使用できません。"
+            nickname:
+              blank: "を入力してください。"
+              invalid: "は有効でありません。"
+            birthday:
+              blank: "を入力してください。"
+              invalid: "は有効でありません。"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にログイン"
+        name_last: "姓"
+        name_first: "名"
+        name_kana_last: "姓カナ"
+        name_kana_first: "名カナ"
+        nickname: "ニックネーム"
+        birthday: "誕生日"
+  recaptcha:
+    errors:
+      verification_failed: 'reCAPTCHA認証をしてください'
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}。'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません。"
+          has_many: "%{record}が存在しているので削除できません。"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください。
+      blank: を入力してください。
+      confirmation: と%{attribute}の入力が一致しません。
+      empty: を入力してください。
+      equal_to: は%{count}にしてください。
+      even: は偶数にしてください。
+      exclusion: は予約されています。
+      greater_than: は%{count}より大きい値にしてください。
+      greater_than_or_equal_to: は%{count}以上の値にしてください。
+      inclusion: は一覧にありません。
+      invalid: は不正な値です。
+      less_than: は%{count}より小さい値にしてください。
+      less_than_or_equal_to: は%{count}以下の値にしてください。
+      model_invalid: 'バリデーションに失敗しました: %{errors}。'
+      not_a_number: は数値で入力してください。
+      not_an_integer: は整数で入力してください。
+      odd: は奇数にしてください。
+      other_than: は%{count}以外の値にしてください。
+      present: は入力しないでください。
+      required: を入力してください。
+      taken: はすでに存在します。
+      too_long: は%{count}文字以内で入力してください。
+      too_short: は%{count}文字以上で入力してください。
+      wrong_length: は%{count}文字で入力してください。
+    template:
+      body: 次の項目を確認してください。
+      header:
+        one: "%{model}にエラーが発生しました。"
+        other: "%{model}に%{count}個のエラーが発生しました。"
+  helpers:
+    select:
+      prompt: 選択してください。
+    submit:
+      create: 登録する。
+      submit: 保存する。
+      update: 更新する。
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   root to: 'products#index'
   resources :users do
     collection do

--- a/db/migrate/20190802082856_add_column_to_users.rb
+++ b/db/migrate/20190802082856_add_column_to_users.rb
@@ -1,0 +1,8 @@
+class AddColumnToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_column :users, :token, :string
+    add_column :users, :meta, :string
+  end
+end

--- a/db/migrate/20190803104550_rename_name_column_to_users.rb
+++ b/db/migrate/20190803104550_rename_name_column_to_users.rb
@@ -1,0 +1,6 @@
+class RenameNameColumnToUsers < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :users, :name, :name_last
+    rename_column :users, :name_kana, :name_kana_last
+  end
+end

--- a/db/migrate/20190803104910_add_column_users.rb
+++ b/db/migrate/20190803104910_add_column_users.rb
@@ -1,0 +1,6 @@
+class AddColumnUsers < ActiveRecord::Migration[5.0]
+  def up
+    add_column :users, :name_first, :string
+    add_column :users, :name_kana_first, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20190801120233) do
+ActiveRecord::Schema.define(version: 20190803104910) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",       null: false
@@ -52,7 +51,7 @@ ActiveRecord::Schema.define(version: 20190801120233) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "customer_id", null: false
-    t.string   "card_token",  null: false
+    t.string   "card_id",     null: false
   end
 
   create_table "likes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -110,12 +109,18 @@ ActiveRecord::Schema.define(version: 20190801120233) do
     t.datetime "remember_created_at"
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
-    t.string   "name",                                              null: false
-    t.string   "name_kana"
+    t.string   "name_last",                                         null: false
+    t.string   "name_kana_last"
     t.string   "nickname"
     t.date     "birthday"
     t.string   "phone_number"
     t.text     "profile",                limit: 65535
+    t.string   "provider"
+    t.string   "uid"
+    t.string   "token"
+    t.string   "meta"
+    t.string   "name_first"
+    t.string   "name_kana_first"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
## WHAT

- ユーザー登録時のvalidationを設定しました。

- ユーザー登録失敗時にエラーメッセージを表示するようにしました。

- userテーブルのname欄を苗字と名前で分けて登録するようにしました。

- SNS認証のページ遷移が行えるようにしました。

- reCAPTCHAを導入しました。

## WHY

- どんな文字列でも登録されてしまうとデータベースからの取り出し時などに困る可能性があるため。

- エラーメッセージを出すことによって何がいけないのかユーザーが気づけるため。

- nameにひとまとめにしていると緊急時の変更などに対応しづらいため。

- SNS認証をすることによってユーザー登録を簡単にできるため。

- Bot対策