### PR TITLE
fix main_sidebar

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
 
-  before_action :set_user
+  before_action :set_user, except: :logout
 
   def show
     @user_products = current_user.products

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,8 +20,8 @@ class User < ApplicationRecord
   validates :name_kana_last, presence: true, format: { with: /\p{Katakana}/}
   validates :name_kana_first, presence: true, format: { with: /\p{Katakana}/}
   validates :email, presence: true, unless: :uid?
-  validates :password, presence: true, format: { with: /\A[a-zA-Z\d]+\z/}, unless: :uid?
-  validates :password_confirmation, presence: true, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]/i}, unless: :uid?
+  validates :password, presence: true, format: { with: /\A[a-zA-Z\d]+\z/}, on: :create
+  validates :password_confirmation, presence: true, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]/i}, on: :create
   validates :nickname, presence: true, unless: :uid?
   validates :birthday, presence: true
 

--- a/app/views/shared/_main_sidebar.html.haml
+++ b/app/views/shared/_main_sidebar.html.haml
@@ -70,7 +70,7 @@
     .mypage__head 設定
     %ul.mypage__list
       %li.mypage__list--li
-        = link_to profile_user_path , class: "mypage-link" do
+        = link_to profile_user_path(current_user) , class: "mypage-link" do
           %span プロフィール
           =fa_icon 'angle-right',class:'sideicon fa-lg'
       %li.mypage__list--li

--- a/app/views/shared/_main_sidebar.html.haml
+++ b/app/views/shared/_main_sidebar.html.haml
@@ -94,6 +94,6 @@
           %span 電話番号の確認
           =fa_icon 'angle-right',class:'sideicon fa-lg'
       %li.mypage__list--li
-        = link_to 'logout' , class: "mypage-link" do
+        = link_to logout_users_path , class: "mypage-link" do
           %span ログアウト
           =fa_icon 'angle-right',class:'sideicon fa-lg'


### PR DESCRIPTION
## WHAT

- ログアウトページでset_userが発動しないように変更。

- 一部のvalidationをcreateでのみ反応するように変更。

##WHY

- ログアウトページにはid情報は必要ないため。